### PR TITLE
ps pid's sub process

### DIFF
--- a/scripts/tmux-ssh-split.sh
+++ b/scripts/tmux-ssh-split.sh
@@ -185,7 +185,7 @@ get_ssh_command() {
     return 3
   fi
 
-  ps -o command= -g "${pane_pid}" | while read -r child_cmd
+  ps -o pid=,ppid=,command= | grep "${pane_pid}" | awk '{$1="";$2="";print $0}' | while read -r child_cmd
   do
     if [[ "$child_cmd" =~ ^(auto)?ssh ]]
     then


### PR DESCRIPTION
`ps -o command= -g "${pane_pid}"` only show parent process in my mac, `ssh` command is a sub process