### PR TITLE
SPLIT_ARGS array push when ssh-split-no-env set to false

### DIFF
--- a/scripts/tmux-ssh-split.sh
+++ b/scripts/tmux-ssh-split.sh
@@ -434,7 +434,7 @@ then
 
   if [[ -z "$NO_ENV" ]]
   then
-    SPLIT_ARGS=(-e "TMUX_SSH_SPLIT=1")
+    SPLIT_ARGS+=(-e "TMUX_SSH_SPLIT=1")
   fi
 
   SSH_COMMAND="$(get_ssh_command)"


### PR DESCRIPTION
When @ssh-split-no-env is set to false (default value) it breaks horizontal split since SPLIT_ARGS loses all its elements to only (-e "TMUX_SSH_SPLIT=1"). Since no -h or -v parameter is passed, tmux default split is vertical 