### PR TITLE
Fix new-window when not in ssh

### DIFF
--- a/scripts/tmux-ssh-split.sh
+++ b/scripts/tmux-ssh-split.sh
@@ -446,7 +446,16 @@ then
       tmux display "Error: current pane seems to not be running SSH..."
       echo "Could not determine SSH command" >&2
     else
-      tmux split "${SPLIT_ARGS[@]}"
+      if [[ -n "$WINDOW" ]]
+      then
+        # remove -h and -v from split args
+        SPLIT_ARGS=("${SPLIT_ARGS[@]/-h}")
+        SPLIT_ARGS=("${SPLIT_ARGS[@]/-v}")
+
+        tmux new-window "${SPLIT_ARGS[@]}"
+      else
+        tmux split "${SPLIT_ARGS[@]}"
+      fi
     fi
     exit 0
   fi


### PR DESCRIPTION
When not in ssh session 'split' window does not work, it will split horizontally instead. Added check (same as in L501-L510) to verify if is a new-window or split tmux command.
Btw, not entirely sure if we need ` SPLIT_ARGS=("${SPLIT_ARGS[@]/-h}") ; SPLIT_ARGS=("${SPLIT_ARGS[@]/-v}")` here.